### PR TITLE
Fixed Yosemite support for MachInjectSample.

### DIFF
--- a/mach_inject_bundle/mach_inject_bundle.xcodeproj/project.pbxproj
+++ b/mach_inject_bundle/mach_inject_bundle.xcodeproj/project.pbxproj
@@ -275,11 +275,7 @@
 		33B2AC7809285567004B1632 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					ppc,
-					i386,
-					x86_64,
-				);
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				COPY_PHASE_STRIP = NO;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -333,6 +329,7 @@
 		33B2AC7A09285567004B1632 /* Default */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;

--- a/mach_inject_bundle_stub/mach_inject_bundle_stub.c
+++ b/mach_inject_bundle_stub/mach_inject_bundle_stub.c
@@ -67,8 +67,8 @@ INJECT_ENTRY(
 	__pthread_set_self(dummy_pthread_struct);
 #endif
 
-	fprintf(stderr, "mach_inject_bundle: entered in %s, codeOffset: %td, param: %p, paramSize: %lu\n",
-			INJECT_ENTRY_SYMBOL, codeOffset, param, paramSize);
+//	fprintf(stderr, "mach_inject_bundle: entered in %s, codeOffset: %td, param: %p, paramSize: %lu\n",
+//			INJECT_ENTRY_SYMBOL, codeOffset, param, paramSize);
 
 	pthread_attr_t attr;
 	pthread_attr_init(&attr); 
@@ -96,7 +96,7 @@ INJECT_ENTRY(
 pthread_entry(
 		mach_inject_bundle_stub_param	*param )
 {
-	fprintf(stderr, "mach_inject_bundle: entered in pthread_entry, param: %p\n", param);
+//	fprintf(stderr, "mach_inject_bundle: entered in pthread_entry, param: %p\n", param);
 	assert( param );
 	
 	EventLoopTimerProcPtr proc = (EventLoopTimerProcPtr) EventLoopTimerEntry;
@@ -113,7 +113,7 @@ EventLoopTimerEntry(
 		EventLoopTimerRef				inTimer,
 		mach_inject_bundle_stub_param	*param )
 {
-	fprintf(stderr, "mach_inject_bundle: entered in EventLoopTimerEntry, inTimer: %p, param: %p\n", inTimer, param);
+//	fprintf(stderr, "mach_inject_bundle: entered in EventLoopTimerEntry, inTimer: %p, param: %p\n", inTimer, param);
 	assert( inTimer );
 	assert( param );
 	load_bundle_package( param->bundlePackageFileSystemRepresentation );

--- a/mach_inject_bundle_stub/mach_inject_bundle_stub.xcodeproj/project.pbxproj
+++ b/mach_inject_bundle_stub/mach_inject_bundle_stub.xcodeproj/project.pbxproj
@@ -284,6 +284,7 @@
 				ARCHS = (
 					ppc,
 					i386,
+					x86_64,
 				);
 				FRAMEWORK_SEARCH_PATHS = "";
 				GCC_ENABLE_TRIGRAPHS = NO;

--- a/mach_inject_example/MachInjectSample.xcodeproj/project.pbxproj
+++ b/mach_inject_example/MachInjectSample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B7956BF719EDB03A005EEB36 /* mach_inject_bundle.framework in Resources */ = {isa = PBXBuildFile; fileRef = F0CF07F0166F563E009D198D /* mach_inject_bundle.framework */; };
 		F0ADE0FB166DF941009758CC /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F0ADE0FA166DF941009758CC /* Cocoa.framework */; };
 		F0ADE105166DF941009758CC /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F0ADE103166DF941009758CC /* InfoPlist.strings */; };
 		F0ADE107166DF941009758CC /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F0ADE106166DF941009758CC /* main.m */; };
@@ -445,6 +446,7 @@
 				F0ADE1E1166E0B83009758CC /* Payload.bundle in Resources */,
 				F0ADE105166DF941009758CC /* InfoPlist.strings in Resources */,
 				F0ADE1A1166E0667009758CC /* MainMenu.xib in Resources */,
+				B7956BF719EDB03A005EEB36 /* mach_inject_bundle.framework in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -599,7 +601,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				CODE_SIGN_IDENTITY = "Mac Developer: Erwan Barrier (JVRT6RS6G3)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MachInjectSample/MachInjectSample-Prefix.pch";
@@ -614,7 +616,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				CODE_SIGN_IDENTITY = "Mac Developer: Erwan Barrier (JVRT6RS6G3)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MachInjectSample/MachInjectSample-Prefix.pch";
@@ -629,7 +631,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				CODE_SIGN_IDENTITY = "Mac Developer: Erwan Barrier (JVRT6RS6G3)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Installer/Installer-Prefix.pch";
 				INFOPLIST_FILE = "Installer/Installer-Info.plist";
@@ -653,7 +655,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
-				CODE_SIGN_IDENTITY = "Mac Developer: Erwan Barrier (JVRT6RS6G3)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Installer/Installer-Prefix.pch";
 				INFOPLIST_FILE = "Installer/Installer-Info.plist";
@@ -678,7 +680,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer: Erwan Barrier (JVRT6RS6G3)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Injector/Injector-Prefix.pch";
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../mach_inject_bundle\"";
@@ -705,7 +707,7 @@
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_ENABLE_OBJC_ARC = NO;
-				CODE_SIGN_IDENTITY = "Mac Developer: Erwan Barrier (JVRT6RS6G3)";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Injector/Injector-Prefix.pch";
 				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../mach_inject_bundle\"";


### PR DESCRIPTION
https://github.com/rentzsch/mach_inject/issues/13) and fixed project file.
Changed  code signing value to Mac Developer, commented fprintf calls that prevented injection in Yosemite. Added framework to project resources
